### PR TITLE
security: fix nonce leak and batch verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.0.3
+
+- **SECURITY**: remove `print()` calls in `deterministicSign` that leaked the
+  secret nonce and intermediate values to stdout.
+- **SECURITY**: fix `highestFactorsOf2`, which returned 0 for exact powers of
+  two and corrupted the `jacobi` symbol used by `verify()` (residuosity) and
+  `getK()` (signing nonce parity).
+- Fix `batchVerify`: return the real result (was always `false`), select the
+  Jacobi-1 root for `R`, validate `R` is on-curve, and encode `(a*e) mod n`
+  correctly.
+- Fix `deterministicGetRandA`: uniform coefficient in `[1, n-1]`
+  (`nextInt(1)` always returned 0); reuse a single `Random.secure()`.
+- Fix `hashToInt` to apply the excess right-shift (was a no-op).
+- Require `elliptic` 0.4.x for constant-time (Montgomery-ladder) scalar
+  multiplication.
+- Add a comprehensive test suite (33 tests).
+
 ## 0.0.2
 
 - Update doc

--- a/lib/src/signature.dart
+++ b/lib/src/signature.dart
@@ -62,27 +62,13 @@ Signature deterministicSign(PrivateKey priv, List<int> hash) {
   var k0 = deterministicGetK0(curve, d, hash);
 
   var pointR = curve.scalarBaseMul(intToByte(curve, k0));
-  print(pointR.X);
-  print(pointR.Y);
-  var k = getK(curve, pointR, k0); // getEvenKey
-  print(k);
+  var k = getK(curve, pointR, k0);
   var pointP = curve.scalarBaseMul(d);
   var rX = intToByte(curve, pointR.X);
-  print(pointP.X.toString() +
-      ' ' +
-      pointP.Y.toString() +
-      ' ' +
-      rX.toString() +
-      ' ' +
-      hash.toString());
   var e = getE(curve, pointP, rX, hash);
-  print('e:' + e.toString());
   e = e * priv.D;
-  print(e);
   k = k + e;
-  print(k);
   k = k % curve.n;
-  print(k);
 
   var R = pointR.X;
   var S = k;
@@ -155,7 +141,6 @@ bool batchVerify(List<PublicKey> publicKeys, List<List<int>> messages,
 
   var big7 = BigInt.from(7);
 
-  var result = false;
   for (final i in signatures.asMap().keys) {
     var signature = signatures[i];
     var publicKey = publicKeys[i];
@@ -188,34 +173,35 @@ bool batchVerify(List<PublicKey> publicKeys, List<List<int>> messages,
 
     var y = c.modPow(exp, curve.p);
 
+    // A signature whose r is not a valid x-coordinate is invalid.
     if (y.modPow(BigInt.two, curve.p) != c) {
-      break;
+      return false;
+    }
+
+    // R must be the point whose y has Jacobi symbol 1, matching the signing
+    // convention; otherwise pick the other square root.
+    if (jacobi(y, curve.p) != 1) {
+      y = curve.p - y;
     }
 
     var R = AffinePoint.fromXY(r, y);
 
+    // Random per-signature coefficient a_i (a_0 == 1) so a forged signature
+    // cannot be masked by the linear combination.
     if (i != 0) {
       a = deterministicGetRandA(curve);
     }
 
     var aR = curve.scalarMul(R, intToByte(curve, a));
-    var ae = (a * e);
-    var aeHex = ae.toRadixString(16).padLeft((ae.bitLength + 7) >> 3, '0');
-    var aeBytes = List<int>.generate((ae.bitLength + 7) >> 3,
-        (index) => int.parse(aeHex.substring(2 * index, 2 * index + 2)));
-    var aeP = curve.scalarMul(publicKey, aeBytes);
+    var aeP = curve.scalarMul(publicKey, intToByte(curve, (a * e) % curve.n));
     rs = curve.add(rs, aR);
     rs = curve.add(rs, aeP);
-    s = s * a;
-    ls = ls + s;
+    ls = (ls + a * s) % curve.n;
   }
 
+  // The batch verifies iff (sum a_i*s_i)*G == sum (a_i*R_i + a_i*e_i*P_i).
   var G = curve.scalarBaseMul(intToByte(curve, ls % curve.n));
-  if (G != rs) {
-    return false;
-  }
-
-  return result;
+  return G == rs;
 }
 
 // AggregateSignatures aggregates multiple signatures of different private keys over

--- a/lib/src/signature.dart
+++ b/lib/src/signature.dart
@@ -1,4 +1,5 @@
 import 'dart:core';
+import 'dart:math';
 
 import 'package:elliptic/elliptic.dart';
 import 'package:ninja_asn1/ninja_asn1.dart';
@@ -140,6 +141,7 @@ bool batchVerify(List<PublicKey> publicKeys, List<List<int>> messages,
   var rs = AffinePoint();
 
   var big7 = BigInt.from(7);
+  var rng = Random.secure();
 
   for (final i in signatures.asMap().keys) {
     var signature = signatures[i];
@@ -185,11 +187,14 @@ bool batchVerify(List<PublicKey> publicKeys, List<List<int>> messages,
     }
 
     var R = AffinePoint.fromXY(r, y);
+    if (!curve.isOnCurve(R)) {
+      return false;
+    }
 
     // Random per-signature coefficient a_i (a_0 == 1) so a forged signature
     // cannot be masked by the linear combination.
     if (i != 0) {
-      a = deterministicGetRandA(curve);
+      a = deterministicGetRandA(curve, rng);
     }
 
     var aR = curve.scalarMul(R, intToByte(curve, a));

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -147,16 +147,17 @@ int jacobi(BigInt x, BigInt y) {
 }
 
 int highestFactorsOf2(BigInt x) {
-  // check for the set bits
-  var bits = x.toRadixString(2);
-
-  for (var i = 1; i < bits.length; i++) {
-    if (bits[bits.length - i] != '0') {
-      return i - 1;
-    }
+  // Number of trailing zero bits, i.e. the exponent of the largest power of 2
+  // dividing x (0 for x == 0). Used by jacobi to factor out powers of two.
+  if (x == BigInt.zero) {
+    return 0;
   }
-
-  return 0;
+  var count = 0;
+  while ((x & BigInt.one) == BigInt.zero) {
+    x = x >> 1;
+    count++;
+  }
+  return count;
 }
 
 // deterministicGetRandA returns a cryptographically secure, uniformly

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -22,9 +22,10 @@ BigInt hashToInt(List<int> hash, Curve c) {
       List<String>.generate(
           hash.length, (i) => hash[i].toRadixString(16).padLeft(2, '0')).join(),
       radix: 16);
+  // Right-shift the excess low bits (SECG/OpenSSL bits2int).
   var excess = hash.length * 8 - orderBits;
   if (excess > 0) {
-    ret >> excess;
+    ret = ret >> excess;
   }
   return ret;
 }
@@ -158,13 +159,25 @@ int highestFactorsOf2(BigInt x) {
   return 0;
 }
 
+// deterministicGetRandA returns a cryptographically secure, uniformly
+// distributed batch-verification coefficient in [1, n-1].
 BigInt deterministicGetRandA(Curve curve) {
   var rand = Random.secure();
-  var nMinus2 = curve.n - BigInt.two;
-  var a = BigInt.parse(
-      List<String>.generate(
-          nMinus2.bitLength, (index) => rand.nextInt(1).toString()).join(),
-      radix: 2);
+  var n = curve.n;
+  var byteLen = (n.bitLength + 7) >> 3;
+  var excess = byteLen * 8 - n.bitLength;
 
-  return a + BigInt.one;
+  while (true) {
+    var bytes = List<int>.generate(byteLen, (_) => rand.nextInt(256));
+    var a = BigInt.zero;
+    for (var b in bytes) {
+      a = (a << 8) | BigInt.from(b & 0xff);
+    }
+    if (excess > 0) {
+      a = a >> excess;
+    }
+    if (a >= BigInt.one && a < n) {
+      return a;
+    }
+  }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -160,9 +160,10 @@ int highestFactorsOf2(BigInt x) {
 }
 
 // deterministicGetRandA returns a cryptographically secure, uniformly
-// distributed batch-verification coefficient in [1, n-1].
-BigInt deterministicGetRandA(Curve curve) {
-  var rand = Random.secure();
+// distributed batch-verification coefficient in [1, n-1]. An existing
+// [Random] may be supplied to avoid constructing a new secure RNG per call.
+BigInt deterministicGetRandA(Curve curve, [Random? rng]) {
+  var rand = rng ?? Random.secure();
   var n = curve.n;
   var byteLen = (n.bitLength + 7) >> 3;
   var excess = byteLen * 8 - n.bitLength;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.2
 homepage: https://github.com/c0mm4nd/dart-schnorr
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 # dependencies:
 #   path: ^1.8.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: schnorr
 description: A pure dart package for generic schnorr signature algorithm, supporting all curves in elliptic package. 
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/c0mm4nd/dart-schnorr
 
 environment:
@@ -14,5 +14,5 @@ dev_dependencies:
   test: ^1.16.0
 dependencies:
   crypto: ^3.0.1
-  elliptic: ^0.3.5
+  elliptic: '>=0.4.0 <0.5.0'
   ninja_asn1: ^2.0.0

--- a/test/comprehensive_schnorr_test.dart
+++ b/test/comprehensive_schnorr_test.dart
@@ -1,0 +1,390 @@
+import 'dart:math';
+
+import 'package:elliptic/elliptic.dart';
+import 'package:schnorr/schnorr.dart';
+import 'package:schnorr/src/utils.dart';
+import 'package:test/test.dart';
+
+List<int> _message(int seed) =>
+    List<int>.generate(32, (index) => (seed + index * 17) & 0xff);
+
+PrivateKey _privateKey(Curve curve, BigInt value) => PrivateKey(curve, value);
+
+Matcher _schnorrError(String message) => isA<SchnorrException>()
+    .having((error) => error.message, 'message', message);
+
+void main() {
+  late Curve curve;
+
+  setUp(() {
+    curve = getS256();
+  });
+
+  group('deterministicSign', () {
+    test('round-trips across several private keys', () {
+      final privateValues = <BigInt>[
+        BigInt.one,
+        BigInt.two,
+        BigInt.parse(
+            'b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef',
+            radix: 16),
+        curve.n - BigInt.one,
+      ];
+
+      for (var index = 0; index < privateValues.length; index++) {
+        final privateKey = _privateKey(curve, privateValues[index]);
+        final message = _message(index + 1);
+        final signature = deterministicSign(privateKey, message);
+
+        expect(verify(privateKey.publicKey, message, signature), isTrue,
+            reason: 'private key index $index should round-trip');
+      }
+    });
+
+    test('is deterministic for the same key and message', () {
+      final privateKey = _privateKey(curve, BigInt.from(42));
+      final message = _message(9);
+
+      final first = deterministicSign(privateKey, message);
+      final second = deterministicSign(privateKey, message);
+
+      expect(second.R, first.R);
+      expect(second.S, first.S);
+    });
+
+    test('changes when either the message or private key changes', () {
+      final firstKey = _privateKey(curve, BigInt.from(42));
+      final secondKey = _privateKey(curve, BigInt.from(43));
+      final firstMessage = _message(10);
+      final secondMessage = _message(11);
+
+      final original = deterministicSign(firstKey, firstMessage);
+      final changedMessage = deterministicSign(firstKey, secondMessage);
+      final changedKey = deterministicSign(secondKey, firstMessage);
+
+      expect(<BigInt>[changedMessage.R, changedMessage.S],
+          isNot(<BigInt>[original.R, original.S]));
+      expect(<BigInt>[changedKey.R, changedKey.S],
+          isNot(<BigInt>[original.R, original.S]));
+    });
+
+    test('rejects private keys outside one through n minus one', () {
+      expect(
+        () => deterministicSign(_privateKey(curve, BigInt.zero), _message(12)),
+        throwsA(isA<ErrInvalidPriv>()),
+      );
+      expect(
+        () => deterministicSign(_privateKey(curve, curve.n), _message(12)),
+        throwsA(isA<ErrInvalidPriv>()),
+      );
+    });
+  });
+
+  group('verify', () {
+    test('accepts a valid BIP Schnorr vector', () {
+      final publicKey = PublicKey.fromHex(curve,
+          '0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798');
+      final message = List<int>.filled(32, 0);
+      final signature = Signature.fromRS(
+        BigInt.parse(
+            '787A848E71043D280C50470E8E1532B2DD5D20EE912A45DBDD2BD1DFBF187EF6',
+            radix: 16),
+        BigInt.parse(
+            '7031A98831859DC34DFFEEDDA86831842CCD0079E1F92AF177F7F22CC1DCED05',
+            radix: 16),
+      );
+
+      expect(verify(publicKey, message, signature), isTrue);
+    });
+
+    test('returns false for tampered R and tampered S', () {
+      final privateKey = _privateKey(curve, BigInt.from(99));
+      final message = _message(13);
+      final signature = deterministicSign(privateKey, message);
+
+      expect(
+        verify(privateKey.publicKey, message,
+            Signature.fromRS(signature.R + BigInt.one, signature.S)),
+        isFalse,
+      );
+      expect(
+        verify(
+            privateKey.publicKey,
+            message,
+            Signature.fromRS(
+                signature.R, (signature.S + BigInt.one) % curve.n)),
+        isFalse,
+      );
+    });
+
+    test('returns false for the wrong public key and wrong message', () {
+      final signingKey = _privateKey(curve, BigInt.from(100));
+      final otherKey = _privateKey(curve, BigInt.from(101));
+      final message = _message(14);
+      final signature = deterministicSign(signingKey, message);
+
+      expect(verify(otherKey.publicKey, message, signature), isFalse);
+      expect(verify(signingKey.publicKey, _message(15), signature), isFalse);
+    });
+
+    test('throws when R reaches the field size', () {
+      final privateKey = _privateKey(curve, BigInt.from(102));
+      final signature = deterministicSign(privateKey, _message(16));
+
+      expect(
+        () => verify(privateKey.publicKey, _message(16),
+            Signature.fromRS(curve.p, signature.S)),
+        throwsA(_schnorrError('r is larger than or equal to field size')),
+      );
+    });
+
+    test('throws when S reaches the curve order', () {
+      final privateKey = _privateKey(curve, BigInt.from(103));
+      final signature = deterministicSign(privateKey, _message(17));
+
+      expect(
+        () => verify(privateKey.publicKey, _message(17),
+            Signature.fromRS(signature.R, curve.n)),
+        throwsA(_schnorrError('s is larger than or equal to curve order')),
+      );
+    });
+
+    test('throws for a mutated off-curve public key', () {
+      final privateKey = _privateKey(curve, BigInt.from(104));
+      final publicKey = privateKey.publicKey;
+      final message = _message(18);
+      final signature = deterministicSign(privateKey, message);
+      publicKey.X = BigInt.zero;
+      publicKey.Y = BigInt.zero;
+
+      expect(
+        () => verify(publicKey, message, signature),
+        throwsA(_schnorrError('public key is not on curve secp256k1')),
+      );
+    });
+  });
+
+  group('batchVerify', () {
+    test('accepts a genuine multi-signature batch', () {
+      final privateKeys = <PrivateKey>[
+        _privateKey(curve, BigInt.from(201)),
+        _privateKey(curve, BigInt.from(202)),
+        _privateKey(curve, BigInt.from(203)),
+        _privateKey(curve, BigInt.from(204)),
+      ];
+      final messages = List<List<int>>.generate(
+          privateKeys.length, (index) => _message(20 + index));
+      final signatures = List<Signature>.generate(privateKeys.length,
+          (index) => deterministicSign(privateKeys[index], messages[index]));
+
+      expect(
+        batchVerify(privateKeys.map((key) => key.publicKey).toList(), messages,
+            signatures),
+        isTrue,
+      );
+    });
+
+    test('rejects a batch containing one tampered signature', () {
+      final privateKeys = <PrivateKey>[
+        _privateKey(curve, BigInt.from(205)),
+        _privateKey(curve, BigInt.from(206)),
+        _privateKey(curve, BigInt.from(207)),
+      ];
+      final messages = <List<int>>[_message(24), _message(25), _message(26)];
+      final signatures = List<Signature>.generate(privateKeys.length,
+          (index) => deterministicSign(privateKeys[index], messages[index]));
+      signatures[1] = Signature.fromRS(
+          signatures[1].R, (signatures[1].S + BigInt.one) % curve.n);
+
+      expect(
+        batchVerify(privateKeys.map((key) => key.publicKey).toList(), messages,
+            signatures),
+        isFalse,
+      );
+    });
+
+    test('throws for every empty input and for mismatched lengths', () {
+      final privateKey = _privateKey(curve, BigInt.from(208));
+      final message = _message(27);
+      final signature = deterministicSign(privateKey, message);
+
+      expect(
+          () => batchVerify(
+              <PublicKey>[], <List<int>>[message], <Signature>[signature]),
+          throwsA(isA<SchnorrException>()));
+      expect(
+          () => batchVerify(<PublicKey>[privateKey.publicKey], <List<int>>[],
+              <Signature>[signature]),
+          throwsA(isA<SchnorrException>()));
+      expect(
+          () => batchVerify(<PublicKey>[privateKey.publicKey],
+              <List<int>>[message], <Signature>[]),
+          throwsA(isA<SchnorrException>()));
+      expect(
+          () => batchVerify(
+              <PublicKey>[privateKey.publicKey, privateKey.publicKey],
+              <List<int>>[message],
+              <Signature>[signature]),
+          throwsA(_schnorrError(
+              'all parameters must be an array with the same length')));
+    });
+  });
+
+  group('aggregateSign and combinePublicKeys', () {
+    test('verifies two-key and three-key aggregate signatures', () {
+      final privateKeys = <PrivateKey>[
+        _privateKey(curve, BigInt.from(301)),
+        _privateKey(curve, BigInt.from(302)),
+        _privateKey(curve, BigInt.from(303)),
+      ];
+      final message = _message(30);
+
+      for (final count in <int>[2, 3]) {
+        final selectedKeys = privateKeys.sublist(0, count);
+        final signature = aggregateSign(selectedKeys, message);
+        final publicKey = combinePublicKeys(
+            selectedKeys.map((key) => key.publicKey).toList());
+
+        expect(verify(publicKey, message, signature), isTrue,
+            reason: '$count-key aggregate should verify');
+      }
+    });
+
+    test('combinePublicKeys returns its single input', () {
+      final publicKey = _privateKey(curve, BigInt.from(304)).publicKey;
+
+      final combined = combinePublicKeys(<PublicKey>[publicKey]);
+
+      expect(identical(combined, publicKey), isTrue);
+      expect(combined, publicKey);
+    });
+
+    test('combinePublicKeys equals iterative point addition', () {
+      final publicKeys = <PublicKey>[
+        _privateKey(curve, BigInt.from(305)).publicKey,
+        _privateKey(curve, BigInt.from(306)).publicKey,
+        _privateKey(curve, BigInt.from(307)).publicKey,
+        _privateKey(curve, BigInt.from(308)).publicKey,
+      ];
+      var expected = AffinePoint.fromXY(publicKeys.first.X, publicKeys.first.Y);
+      for (final publicKey in publicKeys.skip(1)) {
+        expected = curve.add(expected, publicKey);
+      }
+
+      final combined = combinePublicKeys(publicKeys);
+
+      expect(combined.X, expected.X);
+      expect(combined.Y, expected.Y);
+    });
+
+    test('empty key lists throw SchnorrException', () {
+      expect(
+          () => combinePublicKeys(<PublicKey>[]),
+          throwsA(
+              _schnorrError('pks must be an array with one or more elements')));
+      expect(() => aggregateSign(<PrivateKey>[], _message(31)),
+          throwsA(isA<SchnorrException>()));
+    });
+  });
+
+  group('Signature serialization', () {
+    test('fromRS toASN1 and fromASN1 round-trip', () {
+      final original = Signature.fromRS(
+          BigInt.parse('80ffffffffffffffff', radix: 16),
+          BigInt.parse('ff00112233445566778899', radix: 16));
+
+      final decoded = Signature.fromASN1(original.toASN1());
+
+      expect(decoded.R, original.R);
+      expect(decoded.S, original.S);
+    });
+
+    test('toASN1Hex and fromASN1Hex round-trip', () {
+      final original =
+          Signature.fromRS(curve.p - BigInt.one, curve.n - BigInt.one);
+      final encoded = original.toASN1Hex();
+
+      final decoded = Signature.fromASN1Hex(encoded);
+
+      expect(decoded.R, original.R);
+      expect(decoded.S, original.S);
+      expect(original.toString(), encoded);
+    });
+  });
+
+  group('utils', () {
+    test('jacobi identifies known residues and non-residues', () {
+      final modulus = BigInt.from(7);
+
+      for (final residue in <int>[1, 2, 4]) {
+        expect(jacobi(BigInt.from(residue), modulus), 1,
+            reason: '$residue is a quadratic residue modulo 7');
+      }
+      for (final nonResidue in <int>[3, 6]) {
+        expect(jacobi(BigInt.from(nonResidue), modulus), -1,
+            reason: '$nonResidue is a quadratic non-residue modulo 7');
+      }
+      expect(jacobi(BigInt.zero, modulus), 0);
+    });
+
+    test('intToByte uses exactly the curve byte length', () {
+      final bytes = intToByte(curve, BigInt.from(0x0102));
+
+      expect(bytes, hasLength((curve.bitSize + 7) ~/ 8));
+      expect(bytes.take(bytes.length - 2), everyElement(0));
+      expect(bytes.sublist(bytes.length - 2), <int>[1, 2]);
+    });
+
+    test('deterministicGetRandA stays in one through n minus one', () {
+      final random = Random(8675309);
+
+      for (var i = 0; i < 64; i++) {
+        final coefficient = deterministicGetRandA(curve, random);
+        expect(coefficient, greaterThanOrEqualTo(BigInt.one));
+        expect(coefficient, lessThan(curve.n));
+      }
+    });
+
+    test('getE is stable and getK selects the Jacobi-positive nonce', () {
+      final privateKey = _privateKey(curve, BigInt.from(401));
+      final nonce = BigInt.from(17);
+      final noncePoint = curve.scalarBaseMul(intToByte(curve, nonce));
+      final rBytes = intToByte(curve, noncePoint.X);
+      final message = _message(40);
+
+      final firstE = getE(curve, privateKey.publicKey, rBytes, message);
+      final secondE = getE(curve, privateKey.publicKey, rBytes, message);
+      final changedE = getE(curve, privateKey.publicKey, rBytes, _message(41));
+
+      expect(firstE, secondE);
+      expect(firstE, greaterThanOrEqualTo(BigInt.zero));
+      expect(firstE, lessThan(curve.n));
+      expect(changedE, isNot(firstE));
+
+      final selectedNonce = getK(curve, noncePoint, nonce);
+      final selectedPoint =
+          curve.scalarBaseMul(intToByte(curve, selectedNonce));
+      expect(
+          selectedNonce == nonce || selectedNonce == curve.n - nonce, isTrue);
+      expect(selectedPoint.X, noncePoint.X);
+      expect(jacobi(selectedPoint.Y, curve.p), 1);
+    });
+
+    test('deterministic nonce and encoding helpers are stable', () {
+      final privateKey = _privateKey(curve, BigInt.from(402));
+      final message = _message(42);
+      final privateBytes = intToByte(curve, privateKey.D);
+
+      final firstNonce = deterministicGetK0(curve, privateBytes, message);
+      final secondNonce = deterministicGetK0(curve, privateBytes, message);
+      final encodedPublicKey = marshal(curve, privateKey.publicKey);
+
+      expect(firstNonce, secondNonce);
+      expect(firstNonce, greaterThanOrEqualTo(BigInt.one));
+      expect(firstNonce, lessThan(curve.n));
+      expect(encodedPublicKey, hasLength(33));
+      expect(encodedPublicKey.first, anyOf(2, 3));
+      expect(highestFactorsOf2(BigInt.from(40)), 3);
+    });
+  });
+}

--- a/test/jacobi_regression_test.dart
+++ b/test/jacobi_regression_test.dart
@@ -1,0 +1,40 @@
+import 'package:elliptic/elliptic.dart';
+import 'package:schnorr/src/utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('highestFactorsOf2 / jacobi regression', () {
+    test('highestFactorsOf2 counts trailing zeros incl. exact powers of two',
+        () {
+      expect(highestFactorsOf2(BigInt.from(1)), 0);
+      expect(highestFactorsOf2(BigInt.from(2)), 1);
+      expect(highestFactorsOf2(BigInt.from(4)), 2);
+      expect(highestFactorsOf2(BigInt.from(8)), 3);
+      expect(highestFactorsOf2(BigInt.from(16)), 4);
+      expect(highestFactorsOf2(BigInt.from(40)), 3); // 8 * 5
+      expect(highestFactorsOf2(BigInt.from(96)), 5); // 32 * 3
+    });
+
+    test('jacobi is correct when the numerator reduces to a power of two', () {
+      // 7^2 == 3 (mod 23), so 3 is a quadratic residue mod 23.
+      expect(jacobi(BigInt.from(3), BigInt.from(23)), 1);
+      // 5 is a quadratic non-residue mod 23.
+      expect(jacobi(BigInt.from(5), BigInt.from(23)), -1);
+
+      // Cross-check against Euler's criterion on the secp256k1 field prime,
+      // exercising power-of-two numerators (2, 8, 2^40).
+      var p = getS256().p;
+      for (var a in [
+        BigInt.two,
+        BigInt.from(8),
+        BigInt.one << 40,
+        BigInt.from(3),
+        BigInt.from(7),
+      ]) {
+        var euler = a.modPow((p - BigInt.one) >> 1, p);
+        var expected = euler == BigInt.one ? 1 : -1;
+        expect(jacobi(a, p), expected, reason: 'a=$a');
+      }
+    });
+  });
+}

--- a/test/schnorr_test.dart
+++ b/test/schnorr_test.dart
@@ -262,6 +262,30 @@ void main() {
       }
     });
 
+    test('batchVerify', () {
+      var pubs = <PublicKey>[];
+      var msgs = <List<int>>[];
+      var sigs = <Signature>[];
+      for (final tc in testCases) {
+        if (tc.priv == '') {
+          continue;
+        }
+        var priv = PrivateKey.fromHex(curve, tc.priv);
+        var m = List<int>.generate(tc.m.length ~/ 2,
+            (i) => int.parse(tc.m.substring(2 * i, 2 * i + 2), radix: 16));
+        pubs.add(priv.publicKey);
+        msgs.add(m);
+        sigs.add(deterministicSign(priv, m));
+      }
+
+      // A batch of genuine signatures verifies.
+      expect(batchVerify(pubs, msgs, sigs), isTrue);
+
+      // Tampering with a single signature makes the whole batch fail.
+      sigs[0] = Signature.fromRS(sigs[0].R, (sigs[0].S + BigInt.one) % curve.n);
+      expect(batchVerify(pubs, msgs, sigs), isFalse);
+    });
+
     test('test verify', () {
       for (final tc in testCases) {
         if (tc.sig ==


### PR DESCRIPTION
Security-audit remediation for the `schnorr` package.

### Changes
- **Nonce leakage (Critical).** `deterministicSign` printed the secret nonce `k` and intermediate secret values to stdout via `print()`. Removed.
- **`jacobi` correctness (High).** `highestFactorsOf2` returned `0` for exact powers of two (2, 4, 8, …), corrupting the Jacobi symbol — e.g. `jacobi(3, 23)` returned `-1` although 3 is a quadratic residue mod 23. `jacobi` drives `verify()`'s residuosity check and `getK()`'s signing nonce parity, so this could produce wrong verification results and non-standard nonce selection. Fixed to count trailing zero bits correctly. (Found by an independent test pass.)
- **Batch verification (High).** `batchVerify` ended with `return result;` where `result` was always `false`, so it rejected every batch. It also picked an arbitrary square root for `R` and encoded the `a*e` scalar with a broken byte routine. Now it returns the real result, selects the Jacobi-1 root, encodes `(a*e) mod n` correctly, and explicitly checks `R` is on-curve.
- **Broken randomness (High).** `deterministicGetRandA` built its coefficient from `nextInt(1)`, which always returns 0, so the batch coefficient was always 1 — defeating the random linear combination. Now uniform in `[1, n-1]` (and reuses a single `Random.secure()`).
- **`hashToInt` no-op shift (Medium).** `ret >> excess;` discarded its result; now applied.

### Tests
`dart test` passes — **33 tests**, including a comprehensive suite covering `deterministicSign`, `verify` (positive/negative/throwing), `batchVerify`, `aggregateSign`/`combinePublicKeys`, `Signature` ASN.1 round-trips, and utils; plus a `jacobi`/`highestFactorsOf2` regression cross-checked against Euler's criterion.

### Note (out of scope)
This package implements the pre-BIP-340 draft (plain SHA-256, naive key aggregation). Migrating to BIP-340 tagged hashes / MuSig-style aggregation is a separate, larger change.